### PR TITLE
Be more permissive with version contraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "homepage": "https://github.com/DASPRiD/container-interop-doctrine",
     "license" : "BSD-2-Clause",
     "require": {
-        "php": "^5.5|^5.6|^7.0|^7.1",
+        "php": "5.5.*|5.6.*|7.0.*|7.1.*",
         "doctrine/orm": "^2.5",
         "container-interop/container-interop": "^1.1",
         "doctrine/dbal": "^2.5",

--- a/composer.json
+++ b/composer.json
@@ -5,11 +5,11 @@
     "homepage": "https://github.com/DASPRiD/container-interop-doctrine",
     "license" : "BSD-2-Clause",
     "require": {
-        "php": "^5.5|^7.0",
+        "php": "^5.5|^5.6|^7.0|^7.1",
         "doctrine/orm": "^2.5",
         "container-interop/container-interop": "^1.1",
         "doctrine/dbal": "^2.5",
-        "doctrine/common": "^2.6"
+        "doctrine/common": "^2.6|^2.7"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Allows installing `doctrine/common:2.7.0` etc. but also explicitly defines `php:5.6` and `php:7.1` (I know it works without, but it takes a moment to figure out what's going on)

Fixes #14 