### PR TITLE
Add global basename support

### DIFF
--- a/example/full-config.php
+++ b/example/full-config.php
@@ -63,6 +63,7 @@ return [
                 'paths' => [],
                 'extension' => null,
                 'drivers' => [],
+                'global_basename' => null,
             ]
         ],
         'cache' => [

--- a/src/DriverFactory.php
+++ b/src/DriverFactory.php
@@ -67,7 +67,7 @@ class DriverFactory extends AbstractFactory
             $driver = new $config['class']($config['paths']);
         }
 
-        if (isset($config['global_basename']) && $driver instanceof FileDriver) {
+        if (array_key_exists('global_basename', $config) && $driver instanceof FileDriver) {
             $driver->setGlobalBasename($config['global_basename']);
         }
 

--- a/src/DriverFactory.php
+++ b/src/DriverFactory.php
@@ -73,6 +73,10 @@ class DriverFactory extends AbstractFactory
             $driver->setLocator(new DefaultFileLocator($locator->getPaths(), $config['extension']));
         }
 
+        if (isset($config['global_basename']) && $driver instanceof FileDriver) {
+            $driver->setGlobalBasename($config['global_basename']);
+        }
+
         if ($driver instanceof MappingDriverChain) {
             foreach ($config['drivers'] as $namespace => $driverName) {
                 if (null === $driverName) {

--- a/src/DriverFactory.php
+++ b/src/DriverFactory.php
@@ -55,22 +55,16 @@ class DriverFactory extends AbstractFactory
                 ),
                 $config['paths']
             );
-        } else {
-            $driver = new $config['class']($config['paths']);
         }
 
-        if (null !== $config['extension'] && $driver instanceof FileDriver) {
-            $locator = $driver->getLocator();
+        if (null !== $config['extension']
+            && (FileDriver::class === $config['class'] || is_subclass_of($config['class'], FileDriver::class))
+        ) {
+            $driver = new $config['class']($config['paths'], $config['extension']);
+        }
 
-            if (get_class($locator) !== DefaultFileLocator::class) {
-                throw new Exception\DomainException(sprintf(
-                    'File locator must be a concrete instance of %s, got %s',
-                    DefaultFileLocator::class,
-                    get_class($locator)
-                ));
-            }
-
-            $driver->setLocator(new DefaultFileLocator($locator->getPaths(), $config['extension']));
+        if (! isset($driver)) {
+            $driver = new $config['class']($config['paths']);
         }
 
         if (isset($config['global_basename']) && $driver instanceof FileDriver) {

--- a/src/DriverFactory.php
+++ b/src/DriverFactory.php
@@ -61,14 +61,14 @@ class DriverFactory extends AbstractFactory
             && (FileDriver::class === $config['class'] || is_subclass_of($config['class'], FileDriver::class))
         ) {
             $driver = new $config['class']($config['paths'], $config['extension']);
+
+            if (isset($config['global_basename'])) {
+                $driver->setGlobalBasename($config['global_basename']);
+            }
         }
 
         if (! isset($driver)) {
             $driver = new $config['class']($config['paths']);
-        }
-
-        if (isset($config['global_basename']) && $driver instanceof FileDriver) {
-            $driver->setGlobalBasename($config['global_basename']);
         }
 
         if ($driver instanceof MappingDriverChain) {

--- a/src/DriverFactory.php
+++ b/src/DriverFactory.php
@@ -61,14 +61,14 @@ class DriverFactory extends AbstractFactory
             && (FileDriver::class === $config['class'] || is_subclass_of($config['class'], FileDriver::class))
         ) {
             $driver = new $config['class']($config['paths'], $config['extension']);
-
-            if (isset($config['global_basename'])) {
-                $driver->setGlobalBasename($config['global_basename']);
-            }
         }
 
         if (! isset($driver)) {
             $driver = new $config['class']($config['paths']);
+        }
+
+        if (isset($config['global_basename']) && $driver instanceof FileDriver) {
+            $driver->setGlobalBasename($config['global_basename']);
         }
 
         if ($driver instanceof MappingDriverChain) {

--- a/test/DriverFactoryTest.php
+++ b/test/DriverFactoryTest.php
@@ -43,7 +43,7 @@ class DriverFactoryTest extends TestCase
         $factory = new DriverFactory();
 
         $driver = $factory($container->reveal());
-        static::assertSame($globalBasename, $driver->getGlobalBasename());
+        $this->assertSame($globalBasename, $driver->getGlobalBasename());
     }
 
     /**
@@ -72,8 +72,8 @@ class DriverFactoryTest extends TestCase
 
         /** @var Driver\SimplifiedXmlDriver $driver */
         $driver = $factory($container->reveal());
-        static::assertInstanceOf($driverClass, $driver);
-        static::assertSame($extension, $driver->getLocator()->getFileExtension());
+        $this->assertInstanceOf($driverClass, $driver);
+        $this->assertSame($extension, $driver->getLocator()->getFileExtension());
     }
 
     public function simplifiedDriverClassProvider()

--- a/test/DriverFactoryTest.php
+++ b/test/DriverFactoryTest.php
@@ -42,6 +42,6 @@ class DriverFactoryTest extends TestCase
         $factory = new DriverFactory();
 
         $driver = $factory($container->reveal());
-        $this->assertSame($globalBasename, $driver->getGlobalBasename());
+        static::assertSame($globalBasename, $driver->getGlobalBasename());
     }
 }

--- a/test/DriverFactoryTest.php
+++ b/test/DriverFactoryTest.php
@@ -3,8 +3,6 @@
  * @license See the file LICENSE for copying permission
  */
 
-declare(strict_types = 1);
-
 namespace ContainerInteropDoctrineTest;
 
 use OutOfBoundsException;

--- a/test/DriverFactoryTest.php
+++ b/test/DriverFactoryTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * @license See the file LICENSE for copying permission
+ */
+
+declare(strict_types = 1);
+
+namespace ContainerInteropDoctrineTest;
+
+use OutOfBoundsException;
+use ContainerInteropDoctrine\DriverFactory;
+use Interop\Container\ContainerInterface;
+use PHPUnit_Framework_TestCase as TestCase;
+
+class DriverFactoryTest extends TestCase
+{
+    public function testMissingClassKeyWillReturnOutOfBoundException()
+    {
+        $container = $this->prophesize(ContainerInterface::class);
+        $factory = new DriverFactory();
+
+        $this->setExpectedException(OutOfBoundsException::class, 'Missing "class" config key');
+
+        $factory($container->reveal());
+    }
+
+    public function testItSupportsGlobalBasenameOptionOnFileDrivers()
+    {
+        $globalBasename = 'foobar';
+
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->has('config')->willReturn(true);
+        $container->get('config')->willReturn([
+            'doctrine' => [
+                'driver' => [
+                    'orm_default' => [
+                        'class' => TestAsset\StubFileDriver::class,
+                        'global_basename' => $globalBasename
+                    ],
+                ],
+            ],
+        ]);
+
+        $factory = new DriverFactory();
+
+        $driver = $factory($container->reveal());
+        $this->assertSame($globalBasename, $driver->getGlobalBasename());
+    }
+}

--- a/test/TestAsset/StubFileDriver.php
+++ b/test/TestAsset/StubFileDriver.php
@@ -3,8 +3,6 @@
  * @license See the file LICENSE for copying permission
  */
 
-declare(strict_types = 1);
-
 namespace ContainerInteropDoctrineTest\TestAsset;
 
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;

--- a/test/TestAsset/StubFileDriver.php
+++ b/test/TestAsset/StubFileDriver.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @license See the file LICENSE for copying permission
+ */
+
+declare(strict_types = 1);
+
+namespace ContainerInteropDoctrineTest\TestAsset;
+
+use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Common\Persistence\Mapping\Driver\FileDriver;
+
+class StubFileDriver extends FileDriver
+{
+    protected function loadMappingFile($file)
+    {
+        return [];
+    }
+
+    public function loadMetadataForClass($className, ClassMetadata $metadata)
+    {
+    }
+}


### PR DESCRIPTION
This PR add to `DriverFactory` the ability to use a `global_basename` key in the driver options, only relevant for `Doctrine\Common\Persistence\Mapping\Driver\FileDriver` implementations.

This makes possible to correctly configure an instance of `Doctrine\ORM\Mapping\Driver\SimplifiedXmlDriver`, which [requires setting that property to work as intended](http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/xml-mapping.html#simplified-xml-driver).