### PR TITLE
Add custom doctrine types before mapping them

### DIFF
--- a/src/ConnectionFactory.php
+++ b/src/ConnectionFactory.php
@@ -12,6 +12,7 @@ namespace ContainerInteropDoctrine;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\PDOMySql\Driver as PdoMysqlDriver;
 use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Types\Type;
 use Interop\Container\ContainerInterface;
 
 /**
@@ -20,10 +21,17 @@ use Interop\Container\ContainerInterface;
 class ConnectionFactory extends AbstractFactory
 {
     /**
+     * @var bool
+     */
+    private static $areTypesRegistered = false;
+
+    /**
      * {@inheritdoc}
      */
     protected function createWithConfig(ContainerInterface $container, $configKey)
     {
+        $this->registerTypes($container);
+
         $config = $this->retrieveConfig($container, $configKey, 'connection');
         $params = $config['params'] + [
             'driverClass' => $config['driver_class'],
@@ -74,5 +82,32 @@ class ConnectionFactory extends AbstractFactory
             'doctrine_mapping_types' => [],
             'doctrine_commented_types' => [],
         ];
+    }
+
+    /**
+     * Registers all declared typed, if not already done.
+     *
+     * @param ContainerInterface $container
+     */
+    private function registerTypes(ContainerInterface $container)
+    {
+        if (self::$areTypesRegistered) {
+            return;
+        }
+
+        $applicationConfig = $container->has('config') ? $container->get('config') : [];
+        $doctrineConfig = array_key_exists('doctrine', $applicationConfig) ? $applicationConfig['doctrine'] : [];
+        $typesConfig = array_key_exists('types', $doctrineConfig) ? $doctrineConfig['types'] : [];
+
+        foreach ($typesConfig as $name => $className) {
+            if (Type::hasType($name)) {
+                Type::overrideType($name, $className);
+                continue;
+            }
+
+            Type::addType($name, $className);
+        }
+
+        self::$areTypesRegistered = true;
     }
 }

--- a/src/ConnectionFactory.php
+++ b/src/ConnectionFactory.php
@@ -98,6 +98,7 @@ class ConnectionFactory extends AbstractFactory
         $applicationConfig = $container->has('config') ? $container->get('config') : [];
         $doctrineConfig = array_key_exists('doctrine', $applicationConfig) ? $applicationConfig['doctrine'] : [];
         $typesConfig = array_key_exists('types', $doctrineConfig) ? $doctrineConfig['types'] : [];
+        self::$areTypesRegistered = true;
 
         foreach ($typesConfig as $name => $className) {
             if (Type::hasType($name)) {
@@ -107,7 +108,5 @@ class ConnectionFactory extends AbstractFactory
 
             Type::addType($name, $className);
         }
-
-        self::$areTypesRegistered = true;
     }
 }

--- a/src/EntityManagerFactory.php
+++ b/src/EntityManagerFactory.php
@@ -9,7 +9,6 @@
 
 namespace ContainerInteropDoctrine;
 
-use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\EntityManager;
 use Interop\Container\ContainerInterface;
 
@@ -19,17 +18,10 @@ use Interop\Container\ContainerInterface;
 class EntityManagerFactory extends AbstractFactory
 {
     /**
-     * @var bool
-     */
-    private static $areTypesRegistered = false;
-
-    /**
      * {@inheritdoc}
      */
     protected function createWithConfig(ContainerInterface $container, $configKey)
     {
-        $this->registerTypes($container);
-
         $config = $this->retrieveConfig($container, $configKey, 'entity_manager');
 
         return EntityManager::create(
@@ -57,32 +49,5 @@ class EntityManagerFactory extends AbstractFactory
             'connection' => $configKey,
             'configuration' => $configKey,
         ];
-    }
-
-    /**
-     * Registers all declared typed, if not already done.
-     *
-     * @param ContainerInterface $container
-     */
-    private function registerTypes(ContainerInterface $container)
-    {
-        if (self::$areTypesRegistered) {
-            return;
-        }
-
-        $applicationConfig = $container->has('config') ? $container->get('config') : [];
-        $doctrineConfig = array_key_exists('doctrine', $applicationConfig) ? $applicationConfig['doctrine'] : [];
-        $typesConfig = array_key_exists('types', $doctrineConfig) ? $doctrineConfig['types'] : [];
-
-        foreach ($typesConfig as $name => $className) {
-            if (Type::hasType($name)) {
-                Type::overrideType($name, $className);
-                continue;
-            }
-
-            Type::addType($name, $className);
-        }
-
-        self::$areTypesRegistered = true;
     }
 }

--- a/test/ConnectionFactoryTest.php
+++ b/test/ConnectionFactoryTest.php
@@ -13,6 +13,7 @@ use ContainerInteropDoctrine\ConnectionFactory;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Driver\PDOSqlite\Driver as PDOSqliteDriver;
 use Doctrine\DBAL\Exception\ConnectionException;
+use Doctrine\DBAL\Types\BooleanType;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Configuration;
 use Interop\Container\ContainerInterface;
@@ -144,6 +145,19 @@ class ConnectionFactoryTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($connection->getDatabasePlatform()->isCommentedDoctrineType($type));
     }
 
+    public function testCustomTypeDoctrineMappingTypesInjection()
+    {
+        $factory = new ConnectionFactory();
+        $property = (new \ReflectionObject($factory))->getProperty('areTypesRegistered');
+        $property->setAccessible(true);
+        $property->setValue($factory, false);
+
+        $connection = $factory($this->buildContainer('orm_default', 'orm_default', 'orm_default', [
+            'doctrine_mapping_types' => ['foo' => 'custom_type'],
+        ])->reveal());
+
+        $this->assertTrue($connection->getDatabasePlatform()->hasDoctrineTypeMappingFor('foo'));
+    }
     /**
      * @param string $ownKey
      * @param string $configurationKey
@@ -166,6 +180,9 @@ class ConnectionFactoryTest extends PHPUnit_Framework_TestCase
                         'driver_class' => PDOSqliteDriver::class,
                     ],
                 ],
+                'types' => [
+                    'custom_type' => BooleanType::class
+                ]
             ],
         ]);
 


### PR DESCRIPTION
This allows creating connection without entitymanager and still have working types.
Before this fix creating connection throwed exception:
```php
[Zend\ServiceManager\Exception\ServiceNotCreatedException]                                                                       
  Service with name "doctrine.connection.orm_default" could not be created. Reason: Type to be overwritten point does not exist. 
```