### PR TITLE
[WIP] Bump minimum version to PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,10 @@ cache:
 matrix:
   fast_finish: true
   include:
-    - php: 5.5
-      env:
-        - EXECUTE_CS_CHECK=true
-    - php: 5.6
+    - php: 7.1
       env:
         - EXECUTE_TEST_COVERALLS=true
-    - php: 7
+        - EXECUTE_CS_CHECK=true
 
 before_install:
   - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi

--- a/composer.json
+++ b/composer.json
@@ -5,11 +5,11 @@
     "homepage": "https://github.com/DASPRiD/container-interop-doctrine",
     "license" : "BSD-2-Clause",
     "require": {
-        "php": "^5.5|^7.0",
-        "doctrine/orm": "^2.5",
+        "php": "^7.1",
         "psr/container": "^1.0.0",
-        "doctrine/dbal": "^2.5",
-        "doctrine/common": "^2.6"
+        "doctrine/orm": "^2.6-dev",
+        "doctrine/dbal": "^2.6",
+        "doctrine/common": "^2.8"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
`container-interop-doctrine` doesn't seem to be installable on my PHP 7.1 system for some reason:

```
$ composer require dasprid/container-interop-doctrine
Using version ^1.0 for dasprid/container-interop-doctrine
./composer.json has been updated
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - doctrine/instantiator 1.0.1 requires php ~5.3 -> your PHP version (7.1.7) does not satisfy that requirement.
    - doctrine/instantiator 1.0.3 requires php ~5.3 -> your PHP version (7.1.7) does not satisfy that requirement.
    - doctrine/instantiator 1.0.2 requires php ~5.3 -> your PHP version (7.1.7) does not satisfy that requirement.
    - Conclusion: don't install doctrine/orm v2.5.0
    - Installation request for dasprid/container-interop-doctrine ^1.0 -> satisfiable by dasprid/container-interop-doctrine[1.0.0].
    - Conclusion: don't install doctrine/instantiator 1.1.0|install doctrine/orm v2.5.0
    - Conclusion: remove doctrine/instantiator 1.1.0|install doctrine/orm v2.5.0
    - dasprid/container-interop-doctrine 1.0.0 requires doctrine/orm ^2.5 -> satisfiable by doctrine/orm[v2.5.0, v2.5.1, v2.5.2, v2.5.3, v2.5.4, v2.5.5, v2.5.6].
    - doctrine/orm v2.5.6 requires doctrine/instantiator ~1.0.1 -> satisfiable by doctrine/instantiator[1.0.1, 1.0.2, 1.0.3, 1.0.4, 1.0.5].
    - doctrine/orm v2.5.5 requires doctrine/instantiator ~1.0.1 -> satisfiable by doctrine/instantiator[1.0.1, 1.0.2, 1.0.3, 1.0.4, 1.0.5].
    - doctrine/orm v2.5.4 requires doctrine/instantiator ~1.0.1 -> satisfiable by doctrine/instantiator[1.0.1, 1.0.2, 1.0.3, 1.0.4, 1.0.5].
    - doctrine/orm v2.5.3 requires doctrine/instantiator ~1.0.1 -> satisfiable by doctrine/instantiator[1.0.1, 1.0.2, 1.0.3, 1.0.4, 1.0.5].
    - doctrine/orm v2.5.2 requires doctrine/instantiator ~1.0.1 -> satisfiable by doctrine/instantiator[1.0.1, 1.0.2, 1.0.3, 1.0.4, 1.0.5].
    - doctrine/orm v2.5.1 requires doctrine/instantiator ~1.0.1 -> satisfiable by doctrine/instantiator[1.0.1, 1.0.2, 1.0.3, 1.0.4, 1.0.5].
    - Can only install one of: doctrine/instantiator[1.0.4, 1.1.0].
    - Can only install one of: doctrine/instantiator[1.0.5, 1.1.0].
    - Installation request for doctrine/instantiator (locked at 1.1.0) -> satisfiable by doctrine/instantiator[1.1.0].


Installation failed, reverting ./composer.json to its original content.
```

Therefore this PR bumps the minimum PHP version to 7.1.

However, at this moment in time, we still need a newer ORM release to be able to merge this.