### PR TITLE
add ability to define a custom platform

### DIFF
--- a/src/ConnectionFactory.php
+++ b/src/ConnectionFactory.php
@@ -39,6 +39,10 @@ class ConnectionFactory extends AbstractFactory
             'pdo' => is_string($config['pdo']) ? $container->get($config['pdo']) : $config['pdo'],
         ];
 
+        if (isset($params['platform'])) {
+            $params['platform'] = $container->get($params['platform']);
+        }
+
         $connection = DriverManager::getConnection(
             $params,
             $this->retrieveDependency(

--- a/test/ConnectionFactoryTest.php
+++ b/test/ConnectionFactoryTest.php
@@ -13,6 +13,7 @@ use ContainerInteropDoctrine\ConnectionFactory;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Driver\PDOSqlite\Driver as PDOSqliteDriver;
 use Doctrine\DBAL\Exception\ConnectionException;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\BooleanType;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Configuration;
@@ -158,6 +159,28 @@ class ConnectionFactoryTest extends PHPUnit_Framework_TestCase
 
         $this->assertTrue($connection->getDatabasePlatform()->hasDoctrineTypeMappingFor('foo'));
     }
+
+    public function testCustomPlatform()
+    {
+        $factory = new ConnectionFactory();
+
+        $config = [
+            'params' => [
+                'platform' => 'custom.platform',
+            ]
+        ];
+
+        $container = $this->buildContainer('orm_default', 'orm_default', 'orm_default', $config);
+
+        $platform = $this->prophesize(AbstractPlatform::class);
+
+        $container->get('custom.platform')->willReturn($platform);
+
+        $connection = $factory($container->reveal());
+
+        $this->assertSame($platform->reveal(), $connection->getDatabasePlatform());
+    }
+
     /**
      * @param string $ownKey
      * @param string $configurationKey


### PR DESCRIPTION
This PR adds the ability to use a custom platform instance by setting a service name as the `params` key of the connection settings.

E.g.
```php
return [
    'doctrine' => [
        'connection' => [
            'orm_default' => [
                'driver_class' => DBAL\Driver\PDOMySql\Driver::class,
                'params' => [
                    'platform' => Acme\Platform::class,
                ],
        ],
];
```

will use retrieve the `Acme\Platform::class` service from the container and use it as platform.
This may be leveraged to avoid triggering automatic platform detection (my specific use case was to generate proxies without a connection ready, i.e. in a Dockerfile).