### PR TITLE
Housekeeping to rename container-interop to PSR-11 in a few places

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,13 @@ matrix:
   fast_finish: true
   include:
     - php: 5.5
-      env:
-        - EXECUTE_CS_CHECK=true
     - php: 5.6
+    - php: 7.0
+    - php: 7.1
+    - php: 7.2
       env:
         - EXECUTE_TEST_COVERALLS=true
-    - php: 7
+        - EXECUTE_CS_CHECK=true
 
 before_install:
   - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# container-interop-doctrine
+# container-interop-doctrine: Doctrine Factories for PSR-11
 
 [![Latest Stable Version](https://poser.pugx.org/dasprid/container-interop-doctrine/v/stable)](https://packagist.org/packages/dasprid/container-interop-doctrine)
 [![Total Downloads](https://poser.pugx.org/dasprid/container-interop-doctrine/downloads)](https://packagist.org/packages/dasprid/container-interop-doctrine)
 [![Build Status](https://api.travis-ci.org/DASPRiD/container-interop-doctrine.png?branch=master)](http://travis-ci.org/DASPRiD/container-interop-doctrine)
 [![Coverage Status](https://coveralls.io/repos/DASPRiD/container-interop-doctrine/badge.png?branch=master)](https://coveralls.io/r/DASPRiD/container-interop-doctrine)
 
-[Doctrine](https://github.com/doctrine) factories for [container-interop](https://github.com/container-interop/container-interop)
+[Doctrine](https://github.com/doctrine) factories for [PSR-11](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-11-container.md) (previously known as `container-interop`).
 
-This package provides a set of factories to be used with containers using the container-interop standard for an easy
+This package provides a set of factories to be used with containers using the PSR-11 standard for an easy
 Doctrine integration in a project.
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "dasprid/container-interop-doctrine",
     "type": "library",
-    "description": "Doctrine factories for container-interop",
+    "description": "Doctrine factories for PSR-11",
     "homepage": "https://github.com/DASPRiD/container-interop-doctrine",
     "license" : "BSD-2-Clause",
     "require": {


### PR DESCRIPTION
Just a bit of housekeeping, updating naming in some places that are important (`README.md` mainly)