### PR TITLE
[Feature] Allow using cosutm cache providers.

### DIFF
--- a/example/full-config.php
+++ b/example/full-config.php
@@ -112,11 +112,14 @@ return [
                 'class' => \Doctrine\Common\Cache\ZendDataCache::class,
                 'namespace' => 'container-interop-doctrine',
             ],
+            'my_cache_provider' => [ 
+                'class' => \App\Doctrine\CustomCacheProvider::class, // its recommended to provide a factory to the container for the custom cache provider 
+            ],
             'chain' => [
                 'class' => \Doctrine\Common\Cache\ChainCache::class,
                 'providers' => ['array', 'redis'], // you can use any provider listed above
                 'namespace' => 'container-interop-doctrine', // will be applied to all providers in the chain
-            ],
+            ]
         ],
         'types' => [],
     ],

--- a/example/full-config.php
+++ b/example/full-config.php
@@ -112,8 +112,9 @@ return [
                 'class' => \Doctrine\Common\Cache\ZendDataCache::class,
                 'namespace' => 'container-interop-doctrine',
             ],
-            'my_cache_provider' => [ 
-                'class' => \App\Doctrine\CustomCacheProvider::class, // its recommended to provide a factory to the container for the custom cache provider 
+            'my_cache_provider' => [
+                // its recommended to provide a factory to the container for the custom cache provider
+                'class' => \App\Doctrine\CustomCacheProvider::class,
             ],
             'chain' => [
                 'class' => \Doctrine\Common\Cache\ChainCache::class,

--- a/example/full-config.php
+++ b/example/full-config.php
@@ -113,8 +113,7 @@ return [
                 'namespace' => 'container-interop-doctrine',
             ],
             'my_cache_provider' => [
-                // its recommended to provide a factory to the container for the custom cache provider
-                'class' => \App\Doctrine\CustomCacheProvider::class,
+                'class' => \App\Doctrine\CustomCacheProvider::class, //The class is looked up in the container
             ],
             'chain' => [
                 'class' => \Doctrine\Common\Cache\ChainCache::class,

--- a/src/CacheFactory.php
+++ b/src/CacheFactory.php
@@ -67,7 +67,7 @@ class CacheFactory extends AbstractFactory
                 break;
 
             default:
-                $cache = new $config['class']();
+                $cache = $container->has($config['class']) ? $container->get($config['class']) : new $config['class']();
         }
 
         if ($cache instanceof MemcacheCache) {

--- a/test/CacheFactoryTest.php
+++ b/test/CacheFactoryTest.php
@@ -11,6 +11,7 @@ namespace ContainerInteropDoctrineTest;
 
 use ContainerInteropDoctrine\AbstractFactory;
 use ContainerInteropDoctrine\CacheFactory;
+use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\Common\Cache\ChainCache;
 use Doctrine\Common\Cache\FilesystemCache;
 use Psr\Container\ContainerInterface;
@@ -74,6 +75,7 @@ class CacheFactoryTest extends PHPUnit_Framework_TestCase
         $container = $this->prophesize(ContainerInterface::class);
         $container->has('config')->willReturn(true);
         $container->get('config')->willReturn($config);
+        $container->has(ArrayCache::class)->willReturn(false);
 
         $factory = new CacheFactory('chain');
         $cacheInstance = $factory($container->reveal());


### PR DESCRIPTION
this will allow using custom cache providers, i made a cache provider bridge that uses a `Psr\Cache\CacheItemPoolInterface`, and it needs the pool as it first argument, its not a problem since i have a factory but it seems to be a problem here as the factory creates a new instance without providing any arguments. 