### PR TITLE
Replace Zend\ServiceManager example with Laminas

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ configurations, there are a few examples provided in the example directory:
 
 - [Aura.Di](example/aura-di.php)
 - [PimpleInterop](example/pimple-interop.php)
-- [Zend\ServiceManager](example/zend-servicemanager.php)
+- [Laminas\ServiceManager](example/laminas-servicemanager.php)
 
 ## Example configuration
 

--- a/example/laminas-servicemanager.php
+++ b/example/laminas-servicemanager.php
@@ -1,5 +1,5 @@
 <?php
-use Zend\ServiceManager\ServiceManager;
+use Laminas\ServiceManager\ServiceManager;
 
 // Standard config keys
 $container = new ServiceManager([


### PR DESCRIPTION
`Zend\ServiceManager` is renamed as `Laminas\ServiceManager` [a while ago](https://getlaminas.org/blog/2019-12-31-out-with-the-old-in-with-the-new.html).

This MR replaces the example for `Zend\ServiceManager` with `Laminas\ServiceManager` and updates the documentation accordingly.